### PR TITLE
Fix/navigation

### DIFF
--- a/app/components/NavigationMenu.js
+++ b/app/components/NavigationMenu.js
@@ -3,26 +3,29 @@ import PropTypes from 'prop-types'
 import MenuIcon from './MenuIcon'
 
 const mainMenuStyle = [
-  'bg-blue-800',
-  'text-blue-100',
-  'w-1/4',
-  'space-y-6',
-  'py-8',
-  'px-4',
-  'absolute',
-  'inset-y-0',
-  'left-0',
-  'transform',
   '-translate-x-full',
-  'transition',
+  'absolute',
+  'bg-blue-800',
   'duration-200',
   'ease-in-out',
+  'inset-y-0',
+  'left-0',
   'md:relative',
   'md:translate-x-0',
+  'px-2',
+  'py-7',
+  'space-y-6',
+  'text-blue-100',
+  'transform',
+  'transition',
+  'w-64',
 ]
+
+const mobileMenuStyle = []
 
 export default function NavigationMenu({ items }) {
   const [menuClasses, setMenuClasses] = useState(mainMenuStyle)
+  const [displayingMobileMenu, setDisplayingMobileMenu] = useState(false)
 
   const handleMobileButtonClick = () => {
     const translateClass = '-translate-x-full'
@@ -32,12 +35,14 @@ export default function NavigationMenu({ items }) {
       : [...menuClasses, translateClass]
 
     setMenuClasses(array)
+    // setDisplayingMobileMenu(!displayingMobileMenu)
+    // setMenuClasses(displayingMobileMenu ? mainMenuStyle : mobileMenuStyle)
   }
 
   return (
     <>
       <div className="bg-gray-800 text-gray-100 flex justify-between md:hidden">
-        <a href="/" className="px-4 text-white flex items-center space-x-2">
+        <a href="/" className="block p-4 text-white font-bold">
           <span className="text-2xl font-bold">React Concepts</span>
         </a>
         <button
@@ -56,7 +61,7 @@ export default function NavigationMenu({ items }) {
             {items.map((item, index) => (
               <li key={index}>
                 <a
-                  className="block py-2.5 px-4 rounded hover:bg-blue-700 transition duration-200"
+                  className="block py-2.5 px-4 rounded transition duration-200 hover:bg-blue-700 hover:text-white"
                   href={item.url}
                 >
                   {item.text}

--- a/app/components/NavigationMenu.js
+++ b/app/components/NavigationMenu.js
@@ -21,22 +21,29 @@ const mainMenuStyle = [
   'w-64',
 ]
 
-const mobileMenuStyle = []
+const mobileMenuStyle = [
+  'bg-blue-800',
+  'duration-200',
+  'ease-in-out',
+  'md:relative',
+  'md:translate-x-0',
+  'px-4',
+  'py-7',
+  'space-y-6',
+  'text-blue-100',
+  'transform',
+  'transition',
+  'w-screen',
+  'text-center',
+]
 
 export default function NavigationMenu({ items }) {
   const [menuClasses, setMenuClasses] = useState(mainMenuStyle)
   const [displayingMobileMenu, setDisplayingMobileMenu] = useState(false)
 
   const handleMobileButtonClick = () => {
-    const translateClass = '-translate-x-full'
-
-    const array = menuClasses.includes(translateClass)
-      ? menuClasses.filter((element) => element !== '-translate-x-full')
-      : [...menuClasses, translateClass]
-
-    setMenuClasses(array)
-    // setDisplayingMobileMenu(!displayingMobileMenu)
-    // setMenuClasses(displayingMobileMenu ? mainMenuStyle : mobileMenuStyle)
+    setDisplayingMobileMenu(!displayingMobileMenu)
+    setMenuClasses(displayingMobileMenu ? mainMenuStyle : mobileMenuStyle)
   }
 
   return (
@@ -53,9 +60,11 @@ export default function NavigationMenu({ items }) {
         </button>
       </div>
       <div className={menuClasses.join(' ')}>
-        <a href="/" className="px-4 text-white flex items-center space-x-2">
-          <span className="text-2xl font-bold">React Concepts</span>
-        </a>
+        {!displayingMobileMenu && (
+          <a href="/" className="px-4 text-white flex items-center space-x-2">
+            <span className="text-2xl font-bold">React Concepts</span>
+          </a>
+        )}
         <nav>
           <ul>
             {items.map((item, index) => (

--- a/app/pages/_app.js
+++ b/app/pages/_app.js
@@ -22,7 +22,7 @@ const items = [
 
 function MyApp({ Component, pageProps }) {
   return (
-    <div className="relative min-h-screen md:flex">
+    <div className="min-h-screen md:flex">
       <NavigationMenu items={items} />
       <div className="flex-1 p-10 text-xl">
         <Component {...pageProps} />


### PR DESCRIPTION
Added mobile style, with ability to toggle between the two
Fixed overflow-y see: https://github.com/danielbutterfield/react-concepts/issues/4
Removed `w-1/4` allowing the nav to be its natural size see: https://github.com/danielbutterfield/react-concepts/issues/5