### PR TITLE
Update mobile menu CSS

### DIFF
--- a/app/components/NavigationMenu.js
+++ b/app/components/NavigationMenu.js
@@ -3,13 +3,13 @@ import PropTypes from 'prop-types'
 import MenuIcon from './MenuIcon'
 
 const mainMenuStyle = [
-  '-translate-y-full',
+  '-translate-x-full',
   'absolute',
   'bg-blue-800',
   'inset-y-0',
   'left-0',
   'md:relative',
-  'md:translate-y-0',
+  'md:translate-x-0',
   'px-2',
   'py-7',
   'space-y-6',

--- a/app/components/NavigationMenu.js
+++ b/app/components/NavigationMenu.js
@@ -45,7 +45,6 @@ export default function NavigationMenu({ items }) {
     <>
       <div className="bg-blue-800 text-gray-100 flex justify-between md:hidden">
         <a href="/" className="block p-4 text-white font-bold">
-          <span className="text-tiny">Not Tiny...?</span>
           <span className="text-2xl font-bold">React Concepts</span>
         </a>
         <button

--- a/app/components/NavigationMenu.js
+++ b/app/components/NavigationMenu.js
@@ -3,37 +3,33 @@ import PropTypes from 'prop-types'
 import MenuIcon from './MenuIcon'
 
 const mainMenuStyle = [
-  '-translate-x-full',
+  '-translate-y-full',
   'absolute',
   'bg-blue-800',
-  'duration-200',
-  'ease-in-out',
   'inset-y-0',
   'left-0',
   'md:relative',
-  'md:translate-x-0',
+  'md:translate-y-0',
   'px-2',
   'py-7',
   'space-y-6',
   'text-blue-100',
   'transform',
-  'transition',
 ]
 
 const mobileMenuStyle = [
-  'absolute',
   'bg-blue-800',
-  'duration-200',
+  'duration-100',
   'ease-in-out',
   'h-full',
   'inset-y-0',
   'px-4',
-  'py-7',
+  'py-2',
+  'relative',
   'space-y-6',
   'text-blue-100',
   'text-center',
   'transition',
-  'w-screen',
 ]
 
 export default function NavigationMenu({ items }) {
@@ -47,12 +43,12 @@ export default function NavigationMenu({ items }) {
 
   return (
     <>
-      <div className="bg-gray-800 text-gray-100 flex justify-between md:hidden">
+      <div className="bg-blue-800 text-gray-100 flex justify-between md:hidden">
         <a href="/" className="block p-4 text-white font-bold">
           <span className="text-2xl font-bold">React Concepts</span>
         </a>
         <button
-          className="p-4 focus:outline-none focus:bg-gray-700"
+          className="p-4 focus:outline-none focus:bg-blue-700"
           onClick={handleMobileButtonClick}
         >
           <MenuIcon />

--- a/app/components/NavigationMenu.js
+++ b/app/components/NavigationMenu.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import MenuIcon from './MenuIcon'
 
 const mainMenuStyle = [
-  '-translate-y-full',
+  '-translate-y-full-xl',
   'absolute',
   'bg-blue-800',
   'inset-y-0',

--- a/app/components/NavigationMenu.js
+++ b/app/components/NavigationMenu.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import MenuIcon from './MenuIcon'
 
 const mainMenuStyle = [
-  '-translate-y-full-xl',
+  '-translate-y-full',
   'absolute',
   'bg-blue-800',
   'inset-y-0',

--- a/app/components/NavigationMenu.js
+++ b/app/components/NavigationMenu.js
@@ -18,23 +18,22 @@ const mainMenuStyle = [
   'text-blue-100',
   'transform',
   'transition',
-  'w-64',
 ]
 
 const mobileMenuStyle = [
+  'absolute',
   'bg-blue-800',
   'duration-200',
   'ease-in-out',
-  'md:relative',
-  'md:translate-x-0',
+  'h-full',
+  'inset-y-0',
   'px-4',
   'py-7',
   'space-y-6',
   'text-blue-100',
-  'transform',
+  'text-center',
   'transition',
   'w-screen',
-  'text-center',
 ]
 
 export default function NavigationMenu({ items }) {

--- a/app/components/NavigationMenu.js
+++ b/app/components/NavigationMenu.js
@@ -45,6 +45,7 @@ export default function NavigationMenu({ items }) {
     <>
       <div className="bg-blue-800 text-gray-100 flex justify-between md:hidden">
         <a href="/" className="block p-4 text-white font-bold">
+          <span className="text-tiny">Not Tiny...?</span>
           <span className="text-2xl font-bold">React Concepts</span>
         </a>
         <button

--- a/app/tailwind.config.js
+++ b/app/tailwind.config.js
@@ -11,9 +11,6 @@ module.exports = {
       full: '200%',
     },
     extend: {
-      translate: {
-        'full-xl': '200%',
-      },
       fontSize: {
         tiny: '1px',
       },

--- a/app/tailwind.config.js
+++ b/app/tailwind.config.js
@@ -7,7 +7,14 @@ module.exports = {
   purge: ['./pages/**/*.{js,ts,jsx,tsx}', './components/**/*.{js,ts,jsx,tsx}'],
   darkMode: false, // or 'media' or 'class'
   theme: {
-    extend: {},
+    translate: {
+      full: '200%',
+    },
+    extend: {
+      fontSize: {
+        tiny: '1px',
+      },
+    },
   },
   variants: {
     extend: {},

--- a/app/tailwind.config.js
+++ b/app/tailwind.config.js
@@ -7,14 +7,7 @@ module.exports = {
   purge: ['./pages/**/*.{js,ts,jsx,tsx}', './components/**/*.{js,ts,jsx,tsx}'],
   darkMode: false, // or 'media' or 'class'
   theme: {
-    translate: {
-      full: '200%',
-    },
-    extend: {
-      fontSize: {
-        tiny: '1px',
-      },
-    },
+    extend: {},
   },
   variants: {
     extend: {},

--- a/app/tailwind.config.js
+++ b/app/tailwind.config.js
@@ -11,6 +11,9 @@ module.exports = {
       full: '200%',
     },
     extend: {
+      translate: {
+        'full-xl': '200%',
+      },
       fontSize: {
         tiny: '1px',
       },


### PR DESCRIPTION
Addresses issue https://github.com/danielbutterfield/react-concepts/issues/8

- Reordered classes to be in alphabetical order
- Removed transition when closing mobile menu
- Updated top mobile banner to match the colour of the mobile menu to make the transition look smoother